### PR TITLE
Add explicit plugin install command to README

### DIFF
--- a/vagrant-guixsd-guest/README.md
+++ b/vagrant-guixsd-guest/README.md
@@ -6,6 +6,15 @@ vagrant-guixsd-guest
 
 Vagrant doesn't natively support GuixSD, and so it needs to be told about it in order to fully support various Vagrant functionality (e.g. clean shutdown). Most of it is from the core Linux support, but there's a small amount of customisation for GuixSD-specific stuff.
 
+### Installing this plugin
+
+The plugin can be fetched over the network via:
+``` bash
+$ vagrant plugin install vagrant-guixsd-guest
+Installing the 'vagrant-guixsd-guest' plugin. This can take a few minutes...
+Fetching vagrant-guixsd-guest-0.1.1.gem
+```
+
 TODO
 ----
 * Make Virtualbox Guest additions work (https://github.com/palfrey/guix-vm/issues/1)


### PR DESCRIPTION
Fix the Vagrant plugin's install being a bit cryptic when we don't know where the package lives & how to fetch it.

My thought process went:
> The [Vagrant docs](https://www.vagrantup.com/docs/plugins/usage#installation) hinted at a `.gem` file to find, which I was thinking I may need to build myself (what a chore). Only when I saw the rubygems.org badge did I think of `vagrant plugin install <the-gem-name-on-rubygems.org>`.

So yeah, to help other dummies like me, let's have a simple install process!

PS: Thanks for the plugin + box, this is really helpful to figure out GuixSD in a safe way.
